### PR TITLE
Modifying incorrect CLI Command

### DIFF
--- a/doc_source/api-gateway-enable-compression.md
+++ b/doc_source/api-gateway-enable-compression.md
@@ -33,7 +33,7 @@ To use the AWS CLI to create a new API and enable compression, call the [http://
 ```
 aws apigateway create-rest-api \
     --name "My test API" \
-    --minimumCompressionSize 0
+    --minimum-compression-size 0
 ```
 
 To use the AWS CLI to enable compression on an existing API, call the [http://docs.aws.amazon.com/cli/latest/reference/apigateway/update-rest-api.html](http://docs.aws.amazon.com/cli/latest/reference/apigateway/update-rest-api.html) command as follows: 


### PR DESCRIPTION

*Issue #, if available:*
CLI command to create a rest API with compression enabled is incorrect, the option must be:
 --minimum-compression-size <INTEGER> 
and not  --minimumCompressionSize as provided in the doc

Reference:
https://docs.aws.amazon.com/cli/latest/reference/apigateway/create-rest-api.html

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
