### PR TITLE
Update apigateway-integrate-with-cognito.md

### DIFF
--- a/doc_source/apigateway-integrate-with-cognito.md
+++ b/doc_source/apigateway-integrate-with-cognito.md
@@ -18,7 +18,7 @@ To create and configure an Amazon Cognito user pool for your API, you perform th
 As the API developer, you must provide your client developers with the user pool ID, a client ID, and possibly the associated client secrets that are defined as part of the user pool\. 
 
 **Note**  
-To let a user sign in using Amazon Cognito credentials and also obtain temporary credentials to use with the permissions of an IAM role, use [Amazon Cognito Federated Identities](http://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html)\. Set the authorization type of your API to `AWS_IAM`\. 
+To let a user sign in using Amazon Cognito credentials and also obtain temporary credentials to use with the permissions of an IAM role, use [Amazon Cognito Federated Identities](http://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html)\. For each api resource endpoint http method, set the authorization type, category `Method Execution`, to `AWS_IAM`\. 
 
 In this section, we describe how to create a user pool, how to integrate an API Gateway API with the user pool, and how to invoke an API that's integrated with the user pool\. 
 


### PR DESCRIPTION
Better description of the location for where to set the apis authorization type.

*Description of changes:*
When I read the description to "Set the authorization type of my API to AWS_IAM", I was confused, because I could't find any place where I could set this type for my whole API. After some research, I found out, that you need to set this option on each resource in the API, so this is why I wanted to change the text, so that future readers don't run into the same question as me and find the respective location more easily. I especially described the exact location, being "for each api resource" and the resource category "Method Execution", where one can find the "authorization type" to set to "AWS_IAM".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
