### PR TITLE
Return type for a Lambda Authorizer

### DIFF
--- a/doc_source/api-gateway-lambda-authorizer-output.md
+++ b/doc_source/api-gateway-lambda-authorizer-output.md
@@ -1,6 +1,6 @@
 # Output from an Amazon API Gateway Lambda Authorizer<a name="api-gateway-lambda-authorizer-output"></a>
 
-A Lambda authorizer function's output must include the principal identifier \(`principalId`\) and a policy document \(`policyDocument`\) containing a list of policy statements\. The output can also include a `context` map containing key\-value pairs\. If the API uses a usage plan \(the [https://docs.aws.amazon.com/apigateway/api-reference/resource/rest-api/#apiKeySource](https://docs.aws.amazon.com/apigateway/api-reference/resource/rest-api/#apiKeySource) is set to `AUTHORIZER`\), the Lambda authorizer function must return one of the usage plan's API keys as the `usageIdentifierKey` property value\.
+A Lambda authorizer function's output is a dictionary-like object, which must include the principal identifier \(`principalId`\) and a policy document \(`policyDocument`\) containing a list of policy statements\. The output can also include a `context` map containing key\-value pairs\. If the API uses a usage plan \(the [https://docs.aws.amazon.com/apigateway/api-reference/resource/rest-api/#apiKeySource](https://docs.aws.amazon.com/apigateway/api-reference/resource/rest-api/#apiKeySource) is set to `AUTHORIZER`\), the Lambda authorizer function must return one of the usage plan's API keys as the `usageIdentifierKey` property value\.
 
 The following shows an example of this output\. 
 


### PR DESCRIPTION
It is currently unclear from the documentation and error messages whether the Lambda Authorizer should return a dictionary/object, or a string containing JSON.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
