### PR TITLE
Fixed cURL command example to invoke API with Public DNS

### DIFF
--- a/doc_source/apigateway-private-apis.md
+++ b/doc_source/apigateway-private-apis.md
@@ -267,7 +267,7 @@ https://{restapi-id}.execute-api.{region}.amazonaws.com/{stage}
 For example, assuming you set up the `GET /pets` and `GET /pets/{petId}` methods in this example, and assuming that your API's API ID was `0qzs2sy7bh` and its public DNS name was `vpce-0c1308d7312217cd7-01234567.execute-api.us-west-1.vpce.amazonaws.com` and your region was `us-west-2`, you could test your API by using the following cURL command:
 
 ```
-curl -v https://vpce-0c1308d7312217cd7-01234567.execute-api.us-east-1.vpce.amazonaws.com/test/get -H'Host:0qzs2sy7bh.execute-api.us-west-2.amazonaws.com'
+curl -v https://vpce-0c1308d7312217cd7-01234567.execute-api.us-west-1.vpce.amazonaws.com/test/pets -H 'Host: 0qzs2sy7bh.execute-api.us-west-2.amazonaws.com'
 ```
 
 ### Accessing Your API Using AWS Direct Connect<a name="w4aac12c15c23c29c13"></a>


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Fixed the cURL command example in the "**Invoking Your API Using Public DNS Names**":
- the region of the vpc endpoint DNS should be us-west-1
- the resource name is /pets and not /get
- there should be a space after the -H option (even if it works without it)
- we could add a space after the 'Host:' header as this is usually how HTTP headers are passed (even if RFC 7230 defines it as optional)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
