### PR TITLE
Fix ARN typo

### DIFF
--- a/doc_source/api-gateway-lambda-authorizer-output.md
+++ b/doc_source/api-gateway-lambda-authorizer-output.md
@@ -28,7 +28,7 @@ The following shows an example of this output\.
 
  Here, a policy statement specifies whether to allow or deny \(`Effect`\) the API Gateway execution service to invoke \(`Action`\) the specified API method \(`Resource`\)\. You can use a wild card \(`*`\) to specify a resource type \(method\)\. For information about setting valid policies for calling an API, see [Statement Reference of IAM Policies for Executing API in API Gateway](api-gateway-control-access-using-iam-policies-to-invoke-api.md#api-gateway-calling-api-permissions)\. 
 
-For an authorization\-enabled method AR, e\.g\., `arn:aws:execute-api:{region-id}:{account-id}:{api-id}/{stage-id}/{method}/{resource}/{path}`, the maximum length is 1600 bytes\. The path parameter values, the size of which are determined at run time, can cause the ARN length to exceed the limit\. When this happens, the API client will receive a `414 Request URI too long` response\. 
+For an authorization\-enabled method ARN, e\.g\., `arn:aws:execute-api:{region-id}:{account-id}:{api-id}/{stage-id}/{method}/{resource}/{path}`, the maximum length is 1600 bytes\. The path parameter values, the size of which are determined at run time, can cause the ARN length to exceed the limit\. When this happens, the API client will receive a `414 Request URI too long` response\. 
 
 In addition, the Resource ARN, as shown in the policy statement output by the authorizer, is currently limited to 512 characters long\. For this reason, you must not use URI with a JWT token of a significant length in a request URI\. You can safely pass the JWT token in a request header, instead\.
 


### PR DESCRIPTION
AR should be ARN.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.