### PR TITLE
Fix WebSocket selection expression and evaluated result

### DIFF
--- a/doc_source/apigateway-websocket-api-selection-expressions.md
+++ b/doc_source/apigateway-websocket-api-selection-expressions.md
@@ -51,7 +51,7 @@ You can simply use a static value, or you can use multiple variables\. The follo
 | $request\.body\.action | join | An unwrapped variable | 
 | $\{request\.body\.action\} | join | A wrapped variable | 
 | $\{request\.body\.service\}/$\{request\.body\.action\} | chat/join | Multiple variables with static values | 
-| $\{request\.body\.action\}\-$\(request\.body\.invalidPath\}  | join | If the JSONPath is not found, the variable will be resolved as ""\. | 
+| $\{request\.body\.action\}\-$\{request\.body\.invalidPath\}  | join- | If the JSONPath is not found, the variable will be resolved as ""\. | 
 | action | action | Static value | 
 | \\$default | $default | Static value | 
 


### PR DESCRIPTION
Description of changes: The expression invalidly had a parenthesis where it should have had a curly brace, and the dash in the expression, which is a static value, was not present in the evaluated result.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
