### PR TITLE
Add note about Accept-Encoding format priorities

### DIFF
--- a/doc_source/api-gateway-enable-compression.md
+++ b/doc_source/api-gateway-enable-compression.md
@@ -68,3 +68,5 @@ API Gateway also supports the following `Accept-Encoding` header format, accordi
 + `Accept-Encoding:*`
 + `Accept-Encoding:deflate;q=0.5,gzip=1.0`
 + `Accept-Encoding:gzip;q=1.0,identity;q=0.5,*;q=0`
+
+The highest priority content coding must be one supported by API Gateway\. If it is not compression is not applied to the response payload\.


### PR DESCRIPTION
As raised/discovered through a support case, API-GW only considers the first type in the header when determining encoding of the content, so it will not compress if it comes across an unsupported encodings such `br` or a malformed encoding format.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
