### PR TITLE
Updating the ARN of the user in the IAM example

### DIFF
--- a/doc_source/apigateway-resource-policies-examples.md
+++ b/doc_source/apigateway-resource-policies-examples.md
@@ -19,7 +19,7 @@ The following example resource policy grants API access in one AWS account to tw
             "Effect": "Allow",
             "Principal": {
                 "AWS": [
-                    "arn:aws:iam::account-id:user/Alice",
+                    "arn:aws:iam::account-id-2:user/Alice",
                     "account-id-2"
                 ]
             },


### PR DESCRIPTION
The documentation mentioned that the user and the root account belonged to account-id-2, however the policy example mentioned account-id which was not mentioned in the text.

*Issue #, if available:*

*Description of changes:*

Updated the ARN for user Alice with the correct reference to account account-id-2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
