### PR TITLE
Lambda proxy integration return values per language

### DIFF
--- a/doc_source/set-up-lambda-proxy-integrations.md
+++ b/doc_source/set-up-lambda-proxy-integrations.md
@@ -583,7 +583,7 @@ The following shows an example of a `requestContext` that is passed to a Lambda 
 
 ## Output Format of a Lambda Function for Proxy Integration<a name="api-gateway-simple-proxy-for-lambda-output-format"></a>
 
-In Lambda proxy integration, API Gateway requires the backend Lambda function to return output according to the following JSON format:
+In Lambda proxy integration, API Gateway requires the backend Lambda function to return output according to the following JSON format for Node.js\/Ruby or a POJO\/object which serializes to the following format in Java\/C#\/Go\/Python:
 
 ```
 {


### PR DESCRIPTION
*Issue #, if available:*
Returning a JSON string in Java when using Lambda Proxy Integration does not work.

*Description of changes:*
The return JSON string specified only works for Node.js and Ruby, if the Lambda is running Java, Python, C#, Go etc they expect POJO objects or objects which serialize to the format. If those languages return a JSON string in the above format, it throws a 502 exception.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
