### PR TITLE
Update api-gateway-enable-compression.md

### DIFF
--- a/doc_source/api-gateway-enable-compression.md
+++ b/doc_source/api-gateway-enable-compression.md
@@ -69,5 +69,5 @@ API Gateway also supports the following `Accept-Encoding` header format, accordi
 + `Accept-Encoding:deflate,gzip`
 + `Accept-Encoding:`
 + `Accept-Encoding:*`
-+ `Accept-Encoding:deflate;q=0.5,gzip=1.0`
++ `Accept-Encoding:compress;q=0.5,gzip;q=1.0`
 + `Accept-Encoding:gzip;q=1.0,identity;q=0.5,*;q=0`


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* There was missing `;q` in one of the `Accept-Encoding` examples
* not sure if `identity` is supported, I didn't had much luck using this compression method with API Gateway responses?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
