### PR TITLE
clarify permissions for logging are regional

### DIFF
--- a/doc_source/set-up-logging.md
+++ b/doc_source/set-up-logging.md
@@ -99,7 +99,7 @@ To enable CloudWatch Logs, you must grant API Gateway permission to read and wri
 **Note**  
 API Gateway will call AWS Security Token Service in order to assume the IAM role, so make sure that AWS STS is enabled for the region\. For more information, see [Managing AWS STS in an AWS Region](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)\.
 
-To grant these permissions to your account, create an IAM role with `apigateway.amazonaws.com` as its trusted entity, attach the preceding policy to the IAM role, and set the IAM role ARN on the [cloudWatchRoleArn](https://docs.aws.amazon.com/apigateway/api-reference/resource/account/#cloudWatchRoleArn) property on your [Account](https://docs.aws.amazon.com/apigateway/api-reference/resource/account/)\.
+To grant these permissions to your account, create an IAM role with `apigateway.amazonaws.com` as its trusted entity, attach the preceding policy to the IAM role, and set the IAM role ARN on the [cloudWatchRoleArn](https://docs.aws.amazon.com/apigateway/api-reference/resource/account/#cloudWatchRoleArn) property on your [Account](https://docs.aws.amazon.com/apigateway/api-reference/resource/account/)\. This must be repeated in each region where API Gateway needs permissions for Cloudwatch Logging.
 
 If you receive an error when setting the IAM role ARN, check your AWS Security Token Service account settings to make sure that AWS STS is enabled in the region that you are using\. For more information about enabling AWS STS, see [Managing AWS STS in an AWS Region](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html#sts-regions-activate-deactivate) in the *IAM User Guide*\.
 


### PR DESCRIPTION
Cloudwatch logging permissions must be set for API Gateway in each region. Add note to reflect this.

*Description of changes:*
 Added a note that API Gateway settings are region-specific, not account-wide.