### PR TITLE
Use multivalueName in request

### DIFF
--- a/doc_source/set-up-lambda-proxy-integrations.md
+++ b/doc_source/set-up-lambda-proxy-integrations.md
@@ -390,7 +390,7 @@ If you specify values for both `headers` and `multiValueHeaders`, API Gateway me
 The following `POST` request shows an API deployed to `testStage` with a stage variable of `stageVariableName=stageVariableValue`:
 
 ```
-POST /testStage/hello/world?name=me HTTP/1.1
+POST /testStage/hello/world?name=me&multivalueName=you&multivalueName=me HTTP/1.1
 Host: gy415nuibc.execute-api.us-east-1.amazonaws.com
 Content-Type: application/json
 headerName: headerValue


### PR DESCRIPTION
This is shown in the event but isn't in the HTTP request, confusingly. As far as I understand, this change is what the request should look like. I haven't tested it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
