### PR TITLE
Added: clarification of validation expression use

### DIFF
--- a/doc_source/apigateway-enable-cognito-user-pool.md
+++ b/doc_source/apigateway-enable-cognito-user-pool.md
@@ -25,7 +25,7 @@ After performing any of the procedures below, you'll need to deploy or redeploy 
 
    1.  For **Token source**, type `Authorization` as the header name to pass the identity or access token that's returned by Amazon Cognito when a user signs in successfully\. 
 
-   1. Optionally, type a regular expression in the **Token validation** field to validate the `aud` \(audience\) field of the identity token before the request is authorized with Amazon Cognito\.
+   1. Optionally, type a regular expression in the **Token validation** field to validate the `aud` \(audience\) field of the identity token before the request is authorized with Amazon Cognito\. Note that when using an access token this validation will reject the request due to the access token not containing the `aud` field.
 
    1. To finish integrating the user pool with the API, choose **Create**\. 
 


### PR DESCRIPTION
*Description of changes:*

In order to use an access token with OAuth Scopes for an API method. The token validation expression must be blank/undefined. Otherwise the API will reject the request with a 401 error code due to the Access token not containing an `aud` field. 

This additional information in the documentation is required as this caveat is not documented anywhere and must be derived from the token structure and this `aud` field validation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
