### PR TITLE
Correction of 1 input term

### DIFF
--- a/doc_source/apigateway-use-lambda-authorizer.md
+++ b/doc_source/apigateway-use-lambda-authorizer.md
@@ -155,7 +155,7 @@ To create a token\-based Lambda authorizer function, enter the following Node\.j
 
 1. For **Lambda Event Payload**, choose **Token**\.
 
-1. For **Token Source**, enter **tokenHeader**\.
+1. For **Token Source**, enter **authorizationToken**\.
 
 1. Choose **Create**, and then choose **Grant & Create**\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Propose change at step 16 of "EXAMPLE: Create a Token-Based Lambda Authorizer Function"  
The original step indicate to enter for *Token Source* **tokenHeader**.  
However, even though this works while testing the authoriser in the APIGW Console, the header used by the sample function provided in the example is **authorizationToken**. Furthermore, when testing the API using for example Postman, and using the header **authorizationToken** as suggested [here](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-input.html), the authorisation fails.  
By entering **authorizationToken** in *Token Source* when configuring the authoriser this can be resolved.

NOTE:
The same change should also be applied at step 19.
For the **tokenHeader** value, enter **allow** should become  
For the **authorizationToken** value, enter **allow**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
