### PR TITLE
pathParameters are also visible in 2.0 payloads

### DIFF
--- a/doc_source/http-api-develop-integrations-lambda.md
+++ b/doc_source/http-api-develop-integrations-lambda.md
@@ -51,6 +51,7 @@ Format `2.0` includes a new `cookies` field\. All cookie headers in the request 
         time: '12/Mar/2020:19:03:58 +0000',
         timeEpoch: 1583348638390
       },
+      pathParameters: {'param1': 'value1'},
       body: 'Hello from Lambda',
       isBase64Encoded: false,
       stageVariables: {'stageVariable1': 'value1', 'stageVariable2': 'value2'}


### PR DESCRIPTION
Like in 1.0 payloads, escaped `pathParameters` are also visible in 2.0 payloads but they were not present in the example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
