### PR TITLE
Correction of 1 input term - 2

### DIFF
--- a/doc_source/apigateway-use-lambda-authorizer.md
+++ b/doc_source/apigateway-use-lambda-authorizer.md
@@ -161,7 +161,7 @@ To create a token\-based Lambda authorizer function, enter the following Node\.j
 
 1. Choose **Test**\.
 
-1. For the **tokenHeader** value, enter **allow**\.
+1. For the **authorizationToken** value, enter **allow**\.
 
 1. Choose **Test**\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Similar to my previous pull request [Correction of 1 input term #61 ](https://github.com/awsdocs/amazon-api-gateway-developer-guide/pull/61) 

Propose the same change also at step 19 of "EXAMPLE: Create a Token-Based Lambda Authorizer Function"

"For the tokenHeader value, enter allow" should become:  
"For the authorizationToken value, enter allow"

Apologies for the double PR but I didn't notice this at first

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
