### PR TITLE
fix for create-authorizer cli command

### DIFF
--- a/doc_source/http-api-jwt-authorizer.md
+++ b/doc_source/http-api-jwt-authorizer.md
@@ -45,7 +45,7 @@ aws apigatewayv2 create-authorizer \
     --api-id api-id \
     --authorizer-type JWT \
     --identity-source '$request.header.Authorization' \
-    --jwt-configuration "Issuer='https://cognito-idp.us-east-2.amazonaws.com/userPoolID', Audience='audience'"
+    --jwt-configuration Audience=audience,Issuer=https://cognito-idp.us-east-2.amazonaws.com/userPoolID
 ```
 
 ## Update a Route to Use a JWT Authorizer by Using the AWS CLI<a name="http-api-jwt-authorizer.create.route"></a>


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Provided example of create-authorizer has incorrect syntax, edited command (specifically jwt-configuration) to reflect proper syntax as stated [in documentation](https://docs.aws.amazon.com/cli/latest/reference/apigatewayv2/create-authorizer.html).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
