### PR TITLE
Fixed VTL Reference Link

### DIFF
--- a/doc_source/request-response-data-mappings.md
+++ b/doc_source/request-response-data-mappings.md
@@ -99,7 +99,7 @@ The following example shows an OpenAPI snippet that maps:
 
 ## Map request and response payloads between method and integration<a name="transforming-request-response-body"></a>
 
- API Gateway uses [Velocity Template Language \(VTL\)](http://velocity.apache.org/engine/devel/vtl-reference-guide.html) engine to process body [mapping templates](rest-api-data-transformations.md#models-mappings-mappings) for the integration request and integration response\. The mapping templates translate method request payloads to the corresponding integration request payloads and translate integration response bodies to the method response bodies\. 
+ API Gateway uses [Velocity Template Language \(VTL\)](https://velocity.apache.org/engine/devel/vtl-reference.html) engine to process body [mapping templates](rest-api-data-transformations.md#models-mappings-mappings) for the integration request and integration response\. The mapping templates translate method request payloads to the corresponding integration request payloads and translate integration response bodies to the method response bodies\. 
 
  The VTL templates use JSONPath expressions, other parameters such as calling contexts and stage variables, and utility functions to process the JSON data\. 
 


### PR DESCRIPTION
Velocity Template Language link was resulting in a 404. I believe I have found the correct reference.  I've also switched the link to https

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
