### PR TITLE
Update set-up-logging.md

### DIFF
--- a/doc_source/set-up-logging.md
+++ b/doc_source/set-up-logging.md
@@ -135,7 +135,7 @@ To set up CloudWatch API logging, you must have deployed the API to a stage\. Yo
 
    1. Choose **Enable Access Logging** under **Custom Access Logging**\.
 
-   1. Enter the ARN of a log group in **Access Log Destination ARN**\. The ARN format is `arn:aws:logs:{region}:{account-id}:log-group:API-Gateway-Execution-Logs_{rest-api-id}/{stage-name}`\.
+   1. Enter the ARN of a log group in **Access Log Destination ARN**\. The ARN format is `arn:aws:logs:{region}:{account-id}:log-group:API-Gateway-Access-Logs_{rest-api-id}/{stage-name}`\.
 
    1. Enter a log format in **Log Format**\. You can choose **CLF**, **JSON**, **XML**, or **CSV** to use one of the provided examples as a guide\.
 


### PR DESCRIPTION
Why would the Access log file & Execution logs file be the same? Shouldn't these two be different since there are two different logs involved here?

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
