### PR TITLE
Fix multiple-value header in payload v2

### DIFF
--- a/doc_source/http-api-develop-integrations-lambda.md
+++ b/doc_source/http-api-develop-integrations-lambda.md
@@ -24,7 +24,7 @@ Format `2.0` includes a new `cookies` field\. All cookie headers in the request 
       cookies: [ 'cookie1', 'cookie2' ],
       headers: {
         'Header1': 'value1',
-        'Header2': 'value2'
+        'Header2': 'value1,value2'
       },
       queryStringParameters: { parameter1: 'value1,value2', parameter2: 'value' },
       requestContext: {


### PR DESCRIPTION
*Description of changes:*

The documentation states:

> Format `2.0` doesn't have `multiValueHeaders` or `multiValueQueryStringParameters` fields\. Duplicate headers are combined with commas and included in the `headers` field\. Duplicate query strings are combined with commas and included in the `queryStringParameters` field.

But then the example contradicts that by skipping the 1st value of the header.

**Please review carefully**, I haven't tested. I am just assuming this is what should happen based on the sentence above. But I believe that either way there is a contradiction to fix here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
