### PR TITLE
Fixed apigatewayv2 create-integration AWS CLI command for HTTP APIs

### DIFF
--- a/doc_source/http-api-develop-integrations-private.md
+++ b/doc_source/http-api-develop-integrations-private.md
@@ -26,6 +26,7 @@ aws apigatewayv2 create-integration --api-id api-id --integration-type HTTP_PROX
     --integration-method GET --connection-type VPC_LINK \
     --connection-id VPC-link-ID \
     --integration-uri arn:aws:elasticloadbalancing:us-east-2:123456789012:listener/app/my-load-balancer/50dc6c495c0c9188/0467ef3c8400ae65
+	--payload-format-version 1.0
 ```
 
 ## Create a private integration using AWS Cloud Map service discovery<a name="http-api-develop-integrations-private-Cloud-Map"></a>
@@ -46,4 +47,5 @@ aws apigatewayv2 create-integration --api-id api-id --integration-type HTTP_PROX
     --integration-method GET --connection-type VPC_LINK \
     --connection-id VPC-link-ID \
     --integration-uri arn:aws:servicediscovery:us-east-2:123456789012:service/srv-id?stage=prod&deployment=green_deployment
+	--payload-format-version 1.0
 ```


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Fixed `apigatewayv2 create-integration` AWS CLI command for HTTP API private integrations in **http-api-develop-integrations-private.md** to include `payload-format-version`. This is [required for HTTP APIs](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/apigatewayv2/create-integration.html): 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
