### PR TITLE
Reformatted the JSON examples

### DIFF
--- a/doc_source/http-api-develop-integrations-lambda.md
+++ b/doc_source/http-api-develop-integrations-lambda.md
@@ -15,103 +15,140 @@ Format `2.0` includes a new `cookies` field\. All cookie headers in the request 
 ------
 #### [ 2\.0 ]
 
-```
+```json
 {
-      version: '2.0',
-      routeKey: '$default',
-      rawPath: '/my/path',
-      rawQueryString: 'parameter1=value1&parameter1=value2&parameter2=value',
-      cookies: [ 'cookie1', 'cookie2' ],
-      headers: {
-        'Header1': 'value1',
-        'Header2': 'value1,value2'
-      },
-      queryStringParameters: { parameter1: 'value1,value2', parameter2: 'value' },
-      requestContext: {
-        accountId: '123456789012',
-        apiId: 'api-id',
-        authorizer: { jwt: {
-            claims: {'claim1': 'value1', 'claim2': 'value2'},
-            scopes: ['scope1', 'scope2']
+    "version": "2.0",
+    "routeKey": "$default",
+    "rawPath": "/my/path",
+    "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+    "cookies": [
+        "cookie1",
+        "cookie2"
+    ],
+    "headers": {
+        "Header1": "value1",
+        "Header2": "value1,value2"
+    },
+    "queryStringParameters": {
+        "parameter1": "value1,value2",
+        "parameter2": "value"
+    },
+    "requestContext": {
+        "accountId": "123456789012",
+        "apiId": "api-id",
+        "authorizer": {
+            "jwt": {
+                "claims": {
+                    "claim1": "value1",
+                    "claim2": "value2"
+                },
+                "scopes": [
+                    "scope1",
+                    "scope2"
+                ]
             }
         },
-        domainName: 'id.execute-api.us-east-1.amazonaws.com',
-        domainPrefix: 'id',
-        http: {
-          method: 'POST',
-          path: '/my/path',
-          protocol: 'HTTP/1.1',
-          sourceIp: 'IP',
-          userAgent: 'agent'
+        "domainName": "id.execute-api.us-east-1.amazonaws.com",
+        "domainPrefix": "id",
+        "http": {
+            "method": "POST",
+            "path": "/my/path",
+            "protocol": "HTTP/1.1",
+            "sourceIp": "IP",
+            "userAgent": "agent"
         },
-        requestId: 'id',
-        routeKey: '$default',
-        stage: '$default',
-        time: '12/Mar/2020:19:03:58 +0000',
-        timeEpoch: 1583348638390
-      },
-      body: 'Hello from Lambda',
-      pathParameters: {'parameter1': 'value1'},
-      isBase64Encoded: false,
-      stageVariables: {'stageVariable1': 'value1', 'stageVariable2': 'value2'}
+        "requestId": "id",
+        "routeKey": "$default",
+        "stage": "$default",
+        "time": "12/Mar/2020:19:03:58 +0000",
+        "timeEpoch": 1583348638390
+    },
+    "body": "Hello from Lambda",
+    "pathParameters": {
+        "parameter1": "value1"
+    },
+    "isBase64Encoded": false,
+    "stageVariables": {
+        "stageVariable1": "value1",
+        "stageVariable2": "value2"
     }
+}
 ```
 
 ------
 #### [ 1\.0 ]
 
-```
+```json
 {
-      version: '1.0',
-      resource: '/my/path',
-      path: '/my/path',
-      httpMethod: 'GET',
-      headers: {
-        'Header1': 'value1',
-        'Header2': 'value2'
-      },
-      multiValueHeaders: {
-        'Header1': [ 'value1' ],
-        'Header2': [ 'value1', 'value2' ]
-      },
-      queryStringParameters: { parameter1: 'value1', parameter2: 'value' },
-      multiValueQueryStringParameters: { parameter1: [ 'value1', 'value2' ], paramter2: [ 'value' ] },
-      requestContext: {
-        accountId: '123456789012',
-        apiId: 'id',
-        authorizer: { claims: null, scopes: null },
-        domainName: 'id.execute-api.us-east-1.amazonaws.com',
-        domainPrefix: 'id',
-        extendedRequestId: 'request-id',
-        httpMethod: 'GET',
-        identity: {
-          accessKey: null,
-          accountId: null,
-          caller: null,
-          cognitoAuthenticationProvider: null,
-          cognitoAuthenticationType: null,
-          cognitoIdentityId: null,
-          cognitoIdentityPoolId: null,
-          principalOrgId: null,
-          sourceIp: 'IP',
-          user: null,
-          userAgent: 'user-agent',
-          userArn: null
+    "version": "1.0",
+    "resource": "/my/path",
+    "path": "/my/path",
+    "httpMethod": "GET",
+    "headers": {
+        "Header1": "value1",
+        "Header2": "value2"
+    },
+    "multiValueHeaders": {
+        "Header1": [
+            "value1"
+        ],
+        "Header2": [
+            "value1",
+            "value2"
+        ]
+    },
+    "queryStringParameters": {
+        "parameter1": "value1",
+        "parameter2": "value"
+    },
+    "multiValueQueryStringParameters": {
+        "parameter1": [
+            "value1",
+            "value2"
+        ],
+        "paramter2": [
+            "value"
+        ]
+    },
+    "requestContext": {
+        "accountId": "123456789012",
+        "apiId": "id",
+        "authorizer": {
+            "claims": null,
+            "scopes": null
         },
-        path: '/my/path',
-        protocol: 'HTTP/1.1',
-        requestId: 'id=',
-        requestTime: '04/Mar/2020:19:15:17 +0000',
-        requestTimeEpoch: 1583349317135,
-        resourceId: null,
-        resourcePath: '/my/path',
-        stage: '$default'
-      },
-      pathParameters: null,
-      stageVariables: null,
-      body: 'Hello from Lambda!',
-      isBase64Encoded: true
-    }
+        "domainName": "id.execute-api.us-east-1.amazonaws.com",
+        "domainPrefix": "id",
+        "extendedRequestId": "request-id",
+        "httpMethod": "GET",
+        "identity": {
+            "accessKey": null,
+            "accountId": null,
+            "caller": null,
+            "cognitoAuthenticationProvider": null,
+            "cognitoAuthenticationType": null,
+            "cognitoIdentityId": null,
+            "cognitoIdentityPoolId": null,
+            "principalOrgId": null,
+            "sourceIp": "IP",
+            "user": null,
+            "userAgent": "user-agent",
+            "userArn": null
+        },
+        "path": "/my/path",
+        "protocol": "HTTP/1.1",
+        "requestId": "id=",
+        "requestTime": "04/Mar/2020:19:15:17 +0000",
+        "requestTimeEpoch": 1583349317135,
+        "resourceId": null,
+        "resourcePath": "/my/path",
+        "stage": "$default"
+    },
+    "pathParameters": null,
+    "stageVariables": null,
+    "body": "Hello from Lambda!",
+    "isBase64Encoded": true
+}
 ```
 
 ------


### PR DESCRIPTION
*Description of changes:*

I reformatted the JSON examples, it's really handy being able to copy these and paste into Lambda Event for testing, or pulling them in as an example for unit tests, but due to them being invalid JSON they fail and require being reformatted first.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
