### PR TITLE
Fix REST private api creation from aws-cli

### DIFF
--- a/doc_source/apigateway-private-apis.md
+++ b/doc_source/apigateway-private-apis.md
@@ -211,6 +211,11 @@ aws apigateway create-rest-api \
     --name Petstore \
     --endpoint-configuration '{ "types": ["PRIVATE"], "vpcEndpointIds" : ["vpce-0212a4ababd5b8c3e", "vpce-0393a628149c867ee"] }' \
     --region us-west-2
+```
+
+A successful call returns output similar to the following:
+
+```
 {
     "apiKeySource": "HEADER",
     "endpointConfiguration": {

--- a/doc_source/apigateway-private-apis.md
+++ b/doc_source/apigateway-private-apis.md
@@ -238,7 +238,7 @@ To associate VPC endpoints to an already created private API, use the following 
 ```
 aws apigateway update-rest-api \
     --rest-api-id u67n3ov968 \
-    --patch-operations "op='add',path='/endpointConfiguration/vpcEndpointIds',value='vpce-01d622316a7df47f9'"
+    --patch-operations "op='add',path='/endpointConfiguration/vpcEndpointIds',value='vpce-01d622316a7df47f9'" \
     --region us-west-2
 ```
 
@@ -271,7 +271,7 @@ To disassociate a VPC endpoint from a private API, use the following CLI command
 ```
 aws apigateway update-rest-api \
     --rest-api-id u67n3ov968 \
-    --patch-operations "op='remove',path='/endpointConfiguration/vpcEndpointIds',value='vpce-0393a628149c867ee'"
+    --patch-operations "op='remove',path='/endpointConfiguration/vpcEndpointIds',value='vpce-0393a628149c867ee'" \
     --region us-west-2
 ```
 


### PR DESCRIPTION
*Description of changes:*

The example of REST private api creation from aws-cli has both command and result in the same markdown snippet box.
The commit split it in two box, one for the command and one for the result.
It should result more clear now.
