### PR TITLE
Correctly indent JSON in Lambda example events

### DIFF
--- a/doc_source/http-api-develop-integrations-lambda.md
+++ b/doc_source/http-api-develop-integrations-lambda.md
@@ -45,9 +45,9 @@ Format `2.0` includes a new `cookies` field\. All cookie headers in the request 
         "validity": {
           "notBefore": "May 28 12:30:02 2019 GMT",
           "notAfter": "Aug  5 09:36:04 2021 GMT"
+        }
       }
-    }
-  },
+    },
     "authorizer": {
       "jwt": {
         "claims": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

It's unusable
&nbsp;&nbsp;&nbsp;with
&nbsp;bad
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;indentation



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
