### PR TITLE
The body is not actually base64 encoded

### DIFF
--- a/doc_source/http-api-develop-integrations-lambda.md
+++ b/doc_source/http-api-develop-integrations-lambda.md
@@ -169,7 +169,7 @@ Format `2.0` includes a new `cookies` field\. All cookie headers in the request 
   "pathParameters": null,
   "stageVariables": null,
   "body": "Hello from Lambda!",
-  "isBase64Encoded": true
+  "isBase64Encoded": false
 }
 ```
 


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
The sample input does not validate because base64 decoding the body fails.

Alternatively, the body could be base64 encoded but that probably removes the utility of having a readable string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
