### PR TITLE
Update apigateway-use-lambda-authorizer.md

### DIFF
--- a/doc_source/apigateway-use-lambda-authorizer.md
+++ b/doc_source/apigateway-use-lambda-authorizer.md
@@ -254,7 +254,7 @@ To create a request\-based Lambda authorizer function, enter the following Node\
        var condition = {};
        condition.IpAddress = {};
         
-       if (headers.HeaderAuth1 === "headerValue1"
+       if (headers.headerauth1 === "headerValue1"
            && queryStringParameters.QueryString1 === "queryValue1"
            && stageVariables.StageVar1 === "stageValue1") {
            callback(null, generateAllow('me', event.methodArn));


### PR DESCRIPTION
Made a slight change in line of code 257, under "EXAMPLE: Create a request-based Lambda authorizer function" section. If 'headerauth' is in fact written with both H and A in capital, the error message displayed will be: "Unauthorized". I tried this code using a request-based Lambda authorizer and running 'curl' command with -H "HeaderAuth1: headerValue1" option and I got the error message above. After that change has been made, everything worked fine.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
