### PR TITLE
replace "IAM policies" with "identity policies"

### DIFF
--- a/doc_source/apigateway-resource-policies.md
+++ b/doc_source/apigateway-resource-policies.md
@@ -11,7 +11,7 @@ For [private APIs](https://docs.aws.amazon.com/apigateway/latest/developerguide/
 
 You can attach a resource policy to an API by using the AWS Management Console, AWS CLI, or AWS SDKs\.
 
-API Gateway resource policies are different from IAM policies\. IAM policies are attached to IAM entities \(users, groups, or roles\) and define what actions those entities are capable of doing on which resources\. API Gateway resource policies are attached to resources\. For a more detailed discussion of the differences between identity\-based \(IAM\) policies and resource policies, see [Identity\-Based Policies and Resource\-Based Policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_identity-vs-resource.html)\.
+API Gateway resource policies are different from identity policies\. identity policies are attached to an IAM user, group, or role and define what actions those identities are capable of doing on which resources\. API Gateway resource policies are attached to resources\. For a more detailed discussion of the differences between identity\-based policies and resource policies, see [Identity\-Based Policies and Resource\-Based Policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_identity-vs-resource.html)\.
 
 You can use API Gateway resource policies together with IAM policies\.
 


### PR DESCRIPTION
Resource and identity policies are both a type of IAM policy, so the documentation is incorrect in assuming a resource policy is different from an IAM policy.  The documentation really means "identity policies". See: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_identity-vs-resource.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
