### PR TITLE
Update payload v2.0 with Lambda authorizer context

### DIFF
--- a/doc_source/http-api-develop-integrations-lambda.md
+++ b/doc_source/http-api-develop-integrations-lambda.md
@@ -59,7 +59,7 @@ Format `2.0` includes a new `cookies` field\. All cookie headers in the request 
           "scope2"
         ]
       },
-      "lambda: {
+      "lambda": {
         "exampleKey1": "exampleValue1",
         "exampleKey2": "exampleValue2"
       }

--- a/doc_source/http-api-develop-integrations-lambda.md
+++ b/doc_source/http-api-develop-integrations-lambda.md
@@ -58,6 +58,10 @@ Format `2.0` includes a new `cookies` field\. All cookie headers in the request 
           "scope1",
           "scope2"
         ]
+      },
+      "lambda: {
+        "exampleKey1": "exampleValue1",
+        "exampleKey2": "exampleValue2"
       }
     },
     "domainName": "id.execute-api.us-east-1.amazonaws.com",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

With the release of the Lambda authorizer for HTTP API Gateway, the example payload doesn't contain the new `lambda` properties passed down from the authorizer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
