### PR TITLE
Missing parenthesis in passthrough behavior tables

### DIFF
--- a/doc_source/integration-passthrough-behaviors.md
+++ b/doc_source/integration-passthrough-behaviors.md
@@ -11,7 +11,7 @@ Example 1: One mapping template is defined in the integration request for the `a
 
 | Content\-type header\\Selected passthrough option | `WHEN_NO_MATCH` | `WHEN_NO_TEMPLATES` | `NEVER` | 
 | --- | --- | --- | --- | 
-| None \(default to application/json | The request payload is transformed using the template\. | The request payload is transformed using the template\. | The request payload is transformed using the template\. | 
+| None \(default to application/json) | The request payload is transformed using the template\. | The request payload is transformed using the template\. | The request payload is transformed using the template\. | 
 | application/json | The request payload is transformed using the template\. | The request payload is transformed using the template\. | The request payload is transformed using the template\. | 
 | application/xml | The request payload is not transformed and is sent to the backend as\-is\. | The request is rejected with an HTTP 415 Unsupported Media Type response\. | The request is rejected with an HTTP 415 Unsupported Media Type response\. | 
 
@@ -20,6 +20,6 @@ Example 2: One mapping template is defined in the integration request for the `a
 
 | Content\-type header\\Selected passthrough option | `WHEN_NO_MATCH` | `WHEN_NO_TEMPLATES` | `NEVER` | 
 | --- | --- | --- | --- | 
-| None \(default to application/json | The request payload is not transformed and is sent to the backend as\-is\. | The request is rejected with an HTTP 415 Unsupported Media Type response\. | The request is rejected with an HTTP 415 Unsupported Media Type response\. | 
+| None \(default to application/json) | The request payload is not transformed and is sent to the backend as\-is\. | The request is rejected with an HTTP 415 Unsupported Media Type response\. | The request is rejected with an HTTP 415 Unsupported Media Type response\. | 
 | application/json | The request payload is not transformed and is sent to the backend as\-is\. | The request is rejected with an HTTP 415 Unsupported Media Type response\. | The request is rejected with an HTTP 415 Unsupported Media Type response\. | 
 | application/xml | The request payload is transformed using the template\. | The request payload is transformed using the template\. | The request payload is transformed using the template\. | 


### PR DESCRIPTION
*Description of changes:*
The closing parentheses are missing in the Integration passthrough behaviors example tables


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
