### PR TITLE
Certain extensions don't work for all API types

### DIFF
--- a/doc_source/api-gateway-swagger-extensions-request-validators.md
+++ b/doc_source/api-gateway-swagger-extensions-request-validators.md
@@ -1,7 +1,8 @@
 # x\-amazon\-apigateway\-request\-validators object<a name="api-gateway-swagger-extensions-request-validators"></a>
 
  Defines the supported request validators for the containing API as a map between a validator name and the associated request validation rules\. This extension applies to an API\.
-
+ 
+HTTP API doesn't support this extension.
 
 **Properties**  
 


### PR DESCRIPTION
This particular extension generates an INFO message when importing using a command line. It's a good idea to update the documentation for similar extensions only working on certain APIs. But some of the extensions do work for any API, e.g. `x-amazon-apigateway-integration`

*Issue #, if available:*
N/A

*Description of changes:*
Added a warning about HTTP API

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
