### PR TITLE
Remove "endpoint" in the description. The correct setting refers to V…

### DIFF
--- a/doc_source/apigateway-private-apis.md
+++ b/doc_source/apigateway-private-apis.md
@@ -181,7 +181,7 @@ When you are ready to test your API, be sure to create a resource policy and att
 
 Before your private API can be accessed, you need to create a resource policy and attach it to the API\. This grants access to the API from your VPCs and VPC endpoints or from VPCs and VPC endpoints in other AWS accounts that you explicitly grant access\.
 
-To do this, follow the instructions in [Create and attach an API Gateway resource policy to an API](apigateway-resource-policies-create-attach.md)\. In step 4, choose the **Source VPC** example\. Replace `{{vpceID}}` \(including the curly braces\) with your VPC endpoint ID, and then choose **Save** to save your resource policy\.
+To do this, follow the instructions in [Create and attach an API Gateway resource policy to an API](apigateway-resource-policies-create-attach.md)\. In step 4, choose the **Source VPC** example\. Replace `{{vpceID}}` \(including the curly braces\) with your VPC ID, and then choose **Save** to save your resource policy\.
 
 You should also consider attaching an endpoint policy to the VPC endpoint to specify the access that's being granted\. For more information, see [Use VPC endpoint policies for private APIs in API Gateway](apigateway-vpc-endpoint-policies.md)\.
 


### PR DESCRIPTION
…PC ID instead of VPC endpoint ID.

*Issue #, if available: The original description is a bit ambiguous which potentially lead to invalid configuration. The value to be used to replace "{{vpcID}}"  shall be the VPC ID instead of VPC Endpoint ID.


*Description of changes:
Removed "endpoint" from the description. The description will become:
`Replace {{vpceID}} \(including the curly braces\) with your VPC ID`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
