### PR TITLE
Fix for UserRoute53Nameservers description

### DIFF
--- a/doc_source/apigateway-developer-portal.md
+++ b/doc_source/apigateway-developer-portal.md
@@ -142,7 +142,7 @@ If you specify **overwrite\-content**, all custom changes in your Amazon S3 buck
 Provide a token different from the last deployment's token to re\-upload the developer portal site's static assets\. You can provide a timestamp or GUID on each deployment to always re\-upload the assets\.
 
 **UseRoute53Nameservers**  
-Only applicable if you're creating a custom domain name for your developer portal\. Specify **true** to skip creating a Route 53 HostedZone and RecordSet\. You'll need to provide your own name server hosting in place of Route 53\. Otherwise, leave this field set to **false**\.
+Only applicable if you're creating a custom domain name for your developer portal\. If set to **true**, a Route 53 HostedZone and RecordSet are created for you\. Otherwise, leave this field set to **false** and provide your own name server hosting in place of Route 53\.
 
 ## Create an admin user for your developer portal<a name="apigateway-developer-portal-create-admin"></a>
 


### PR DESCRIPTION
The description in this documentation seems to suggest the opposite to the description in the serverless application repository (api-gateway-dev-portal — version 4.1.0):

**This doc:**

```
UseRoute53Nameservers
Only applicable if you're creating a custom domain name for your developer portal. Specify true to skip creating a Route 53 HostedZone and RecordSet. You'll need to provide your own name server hosting in place of Route 53. Otherwise, leave this field set to false.
```

**api-gateway-dev-portal — version 4.1.0:**

```
UseRoute53Nameservers
Only applicable if creating a custom domain name for your dev portal. Defaults to false, and you'll need to provide your own nameserver hosting. If set to true, a Route53 HostedZone and RecordSet are created for you.
```

**I'm proposing to change this document to**:

```
UseRoute53Nameservers
Only applicable if you're creating a custom domain name for your developer portal. If set to true, a Route 53 HostedZone and RecordSet are created for you. Otherwise, leave this field set to false and provide your own name server hosting in place of Route 53.
```

Thanks
Eulogio

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
