### PR TITLE
Add missing JSON closing tag

### DIFF
--- a/doc_source/set-up-gateway-responses-in-swagger.md
+++ b/doc_source/set-up-gateway-responses-in-swagger.md
@@ -16,6 +16,7 @@
         "application/json": "{\n     \"message\": $context.error.messageString,\n     \"type\":  \"$context.error.responseType\",\n     \"stage\":  \"$context.stage\",\n     \"resourcePath\":  \"$context.resourcePath\",\n     \"stageVariables.a\":  \"$stageVariables.a\",\n     \"statusCode\": \"'404'\"\n}"
       }
     }
+  }
 ```
 
 In this example, the customization changes the status code from the default \(`403`\) to `404`\. It also adds to the gateway response four header parameters and one body mapping template for the `application/json` media type\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Very minor, close if not worth the change :). Added a missing JSON closing tag in the `x-amazon-apigateway-gateway-responses` example 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
