### PR TITLE
modified usage plan introduction to make it clear that the usage plan applies to each API key separately

### DIFF
--- a/doc_source/api-gateway-api-usage-plans.md
+++ b/doc_source/api-gateway-api-usage-plans.md
@@ -4,7 +4,7 @@ After you create, test, and deploy your APIs, you can use API Gateway usage plan
 
 ## What are usage plans and API keys?<a name="api-gateway-api-usage-plans-overview"></a>
 
-A *usage plan* specifies who can access one or more deployed API stages and methods—and optionally sets the target request rate to start throttling requests\. The plan uses API keys to identify API clients and who can access the associated API stages for each key\. 
+A *usage plan* specifies who can access one or more deployed API stages and methods—and optionally sets a throttling and quota limit on each API key\. Throttling limits define the maximum number of requests per second available to each key\. Quota limits define the number of requests each API key is allowed to make over a period\. The plan uses API keys to identify API clients and who can access the associated API stages for each key.
 
 *API keys* are alphanumeric string values that you distribute to application developer customers to grant access to your API\. You can use API keys together with [Lambda authorizers](apigateway-use-lambda-authorizer.md), [IAM roles](permissions.md), or [Amazon Cognito](apigateway-integrate-with-cognito.md) to control access to your APIs\. API Gateway can generate API keys on your behalf, or you can import them from a [CSV file](api-key-file-format.md)\. You can generate an API key in API Gateway, or import it into API Gateway from an external source\. For more information, see [Set up API keys using the API Gateway console](api-gateway-setup-api-key-with-console.md)\. 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Hello, I've gotten feedback that the documentation for usage plans and api keys does not specify if the api keys will be sharing the throttle/quota for the usage plan. I've made some modifications (borrowed console text) to one paragraph make this more clear. Also there was no mention of quotas so that has been added as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
