### PR TITLE
Update OpenAPI 3.0 known issues

### DIFF
--- a/doc_source/api-gateway-known-issues.md
+++ b/doc_source/api-gateway-known-issues.md
@@ -35,7 +35,7 @@
   + The `example` tag is not supported\.
   + `exclusiveMinimum` is not supported by API Gateway\.
   + The `maxItems` and `minItems` tags are not included in simple request validation\. To work around this, update the model after import before doing validation\.
-  + `oneOf` is not supported by API Gateway\.
+  + `oneOf`, `anyOf`, and `allOf` are not supported by API Gateway\.
   + The `readOnly` field is not supported\.
   + Response definitions of the `"500": {"$ref": "#/responses/UnexpectedError"}` form is not supported in the OpenAPI document root\. To work around this, replace the reference by the inline schema\.
   + Numbers of the `Int32` or `Int64` type are not supported\. An example is shown as follows:


### PR DESCRIPTION
During some testing today I noticed that the AWS Gateway does not except "anyOf" and "allOf" alongside "oneOf" for schema validation. See OpenAPI 3.0 documentation on data model validation for more details: https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/

*Issue #, if available:* None

*Description of changes:* added the other two options available in OpenAPI for data type validation (anyOf and allOf) to the known issues list alongside "oneOf"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
