### PR TITLE
Troubleshooting addition for Lambda Authorizer

### DIFF
--- a/doc_source/http-api-lambda-authorizer.md
+++ b/doc_source/http-api-lambda-authorizer.md
@@ -353,3 +353,5 @@ To troubleshoot errors, [enable access logging](http-api-logging.md) for your AP
 If the logs indicate that API Gateway doesn't have permission to invoke your function, update your function's resource policy or provide an IAM role to grant API Gateway permission to invoke your authorizer\.
 
 If the logs indicate that your Lambda function returns an invalid response, verify that your Lambda function returns a response in the [required format](#http-api-lambda-authorizer.payload-format-response)\.
+
+Ensure that the request being made to API Gateway includes the identity source header, otherwise API Gateway will directly return a 401. In this case there is no authorizer error logged, because the authorizer was not invoked. 


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
Adding note to troubleshooting tips. 

In the case where a request made does not include the identity source, the api gateway returns a 401, without a hint as to why. There's no authoerizer error because the authorizer is never called. This document, as it should, instructs people to use the Authorization header, however it's not something included when running a quick curl / browser GET test. 
In this case it kind of fails silently, and isnt obvious to figure out. This note would have saved me some time. My lambda didnt need a specific header, it authenticates the request in an unconventional way.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
