### PR TITLE
Update integration-requestParameters.md

### DIFF
--- a/doc_source/api-gateway-swagger-extensions-integration-requestParameters.md
+++ b/doc_source/api-gateway-swagger-extensions-integration-requestParameters.md
@@ -17,7 +17,7 @@ For HTTP APIs, specifies parameters that are passed to `AWS_PROXY` integrations 
 The following request parameter mappings example translates a method request's query \(`version`\), header \(`x-user-id`\), and path \(`service`\) parameters to the integration request's query \(`stage`\), header \(`x-userid`\), and path parameters \(`op`\), respectively\.
 
 **Note**  
-If you're creating resources through OpenAPI or AWS CloudFormation, static values should be enclosed in single quotes\.  
+If you're creating resources through OpenAPI or AWS CloudFormation, static values should be enclosed in single quotes as well as double quotes (e.g. `"integration.request.header.x-user-id" : "'static-user-id'"`)\.  
 To add this value from the console, enter `application/json` in the box, without quotation marks\.
 
 ```


### PR DESCRIPTION
*Description of changes:*

Adding more clarity around the `Note` when deploying using CloudFormation or OpenAPI as the static values require single quotes + double quotes. It is a fault that this instruction assumes double quotes are already in use, especially when deploying in a YAML context.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
