### PR TITLE
Change example payload's body to avoid confusion

### DIFF
--- a/doc_source/http-api-develop-integrations-lambda.md
+++ b/doc_source/http-api-develop-integrations-lambda.md
@@ -76,7 +76,7 @@ Format `2.0` includes a new `cookies` field\. All cookie headers in the request 
     "time": "12/Mar/2020:19:03:58 +0000",
     "timeEpoch": 1583348638390
   },
-  "body": "Hello from Lambda",
+  "body": "Hello to Lambda",
   "pathParameters": {
     "parameter1": "value1"
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The example payload shows the format of payload that is sent from API gateway *to* lambda integration. The message in the body might give a different idea.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
