### PR TITLE
REST vs HTTP Api - Merging API Definition

### DIFF
--- a/doc_source/http-api-vs-rest.md
+++ b/doc_source/http-api-vs-rest.md
@@ -69,6 +69,7 @@ As you're developing your API Gateway API, you decide on a number of characteris
 |  [Caching](api-gateway-caching.md)  |  ✓  |    | 
 |  [User\-controlled deployments](how-to-deploy-api.md)  |  [✓](how-to-deploy-api.md)  |  [✓](http-api-stages.md)  | 
 |  [Automatic deployments](http-api-stages.md)  |    |  ✓  | 
+|  [Merge API Definition](api-gateway-import-api-update.html)  |  [✓](api-gateway-import-api-update.html)  |    |
 |  [Custom gateway responses](api-gateway-gatewayResponse-definition.md)  |  ✓  |    | 
 |  [Canary release deployments](canary-release.md)  |  ✓  |    | 
 |  [Request validation](api-gateway-method-request-validation.md)  |  ✓  |    | 


### PR DESCRIPTION
*Issue #, if available:*

Merging API Definition is an awesome feature but is available only in REST ApiGateway and not in HTTP ApiGateway.

*Description of changes:*

I have multiple OpenAPI specifications (each service has its own spec file). Earlier, I need to merge all those spec files into one big spec file and this is used for deploying api gateway which is maintained in a separate repo and hence a separate deployment.

Then I came to know about the ability to import an OpenAPI file to update an existing API definition using merge mode. Using this approach, I can just initiate gateway changes together in same deployment pipeline. Also free from merging and maintaining big swagger.

But this is available only in the REST API gateway and not in the HTTP API gateway.


